### PR TITLE
任意のコードが実行されないようにする

### DIFF
--- a/js/timekeeper.js
+++ b/js/timekeeper.js
@@ -49,7 +49,7 @@ $(function () {
 		if (params.t1 !== undefined) $('#time1').val(params.t1);
 		if (params.t2 !== undefined) $('#time2').val(params.t2);
 		if (params.t3 !== undefined) $('#time3').val(params.t3);
-		if (params.m !== undefined) $('#info').html(params.m);
+		if (params.m !== undefined) $('#info').text(decodeURIComponent(params.m));
 		if (loadedcss !== '') {
 			location.reload();
 		}
@@ -65,7 +65,7 @@ $(function () {
 		var hashstr = '#t1=' + $('#time1').val()
 			+ '&t2=' + $('#time2').val()
 			+ '&t3=' + $('#time3').val()
-			+ '&m=' + encodeURIComponent($('#info').html());
+			+ '&m=' + encodeURIComponent($('#info').text());
 		if (loadedcss !== 'default') {
 			hashstr = hashstr + '&th=' + encodeURIComponent(loadedcss);
 		}
@@ -88,10 +88,10 @@ $(function () {
 		updateHash();
 	});
 
-	var infoline = $('#info').html();
+	var infoline = $('#info').text();
 	$('#info').blur(function () {
-		if (infoline != $(this).html()) {
-			infoline = $(this).html();
+		if (infoline != $(this).text()) {
+			infoline = $(this).text();
 			updateHash();
 		}
 	});


### PR DESCRIPTION
現在、クエリパラメータ`m`の内容が`#info`要素に`html`メソッドを使ってそのままセットされていますが、これを利用すると任意のスクリプトを実行するURLを作れてしまいます。

たとえば
```
https://maruta.github.io/timekeeper/#m=%3Cscript%3Ealert('alert')%3C%2Fscript%3E
```
は
```javascript
alert('alert')
```
をロード時に実行してしまいます（Google Chrome 97で確認しました）。

参考:
- [jQuery - .html()](https://api.jquery.com/html/)の中の"Additional Notes"
- [CAPEC-32: XSS Through HTTP Query Strings](https://capec.mitre.org/data/definitions/32.html)

単純な回避策として、`html`メソッドの代わりに`text`メソッドを使うように変更しました（欠点として、`#info`に入力した改行がクエリパラメータに反映できなくなります）。

また、クエリパラメータ`m`の内容を（`text`メソッドによって）`#info`要素に設定する際に、（`updateHash`で使われている`encodeURIComponent`と対応させて）`decodeURIComponent`を通すようにしました。